### PR TITLE
Add os matrix and command parsing to simple ssh function

### DIFF
--- a/config/nodes.json
+++ b/config/nodes.json
@@ -1,6 +1,7 @@
 {
   "exampleNode": {
     "ip": "192.168.1.1",
+    "port": "22",
     "username": "admin",
     "password": "cisco",
     "os": "ios"

--- a/config/os.json
+++ b/config/os.json
@@ -1,0 +1,14 @@
+{
+  "ios":{
+    "command": "show running-configuration"
+  },
+  "junos":{
+    "command": "show configuration"
+  },
+  "panos":{
+    "command": "show config"
+  },
+  "vyos":{
+    "command": "show configuration"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,39 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+    },
+    "semver": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+    },
+    "ssh2": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.5.5.tgz",
+      "integrity": "sha1-x3gezS7OcwSiU89iD6taXCK7IjU=",
+      "requires": {
+        "ssh2-streams": "0.1.20"
+      }
+    },
+    "ssh2-streams": {
+      "version": "0.1.20",
+      "resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.1.20.tgz",
+      "integrity": "sha1-URGNFUVV31Rp7h9n4M8efoosDjo=",
+      "requires": {
+        "asn1": "0.2.3",
+        "semver": "5.4.1",
+        "streamsearch": "0.1.2"
+      }
+    },
+    "streamsearch": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
+    }
+  }
+}


### PR DESCRIPTION
+ OS matrix matches the os type in the nodes.json file against pre-determined
  operating systems. Their respective commands are then pulled out and parsed to
  the ssh function (depend ssh2) which will ssh to the device given parameters
  and execute the given command.

! Todo : Error handling is messy if existing at all, promise rejection and
   ssh failures need a graceful end.
! Handling of ssh keys as an option would be ideal - at which point we'd need
  to parse a 'connect' object into getConfigConnect, either with password or
  key : /location/to/key baked in (rather than handling it a bit messily on
  connection attempts.